### PR TITLE
fix: support insert style to head when has nest element

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 css-render use `rush` as monorepo manager.
 
-`npm i -g @mircosoft/rush`
+`npm i -g @microsoft/rush`
 
 Before you start to make some change, run `rush update` then `rush install`.

--- a/packages/css-render/__tests__/mount/index.spec.ts
+++ b/packages/css-render/__tests__/mount/index.spec.ts
@@ -178,6 +178,16 @@ describe('head', () => {
       'gogogo'
     )
   })
+  it('mount before link element with nested', () => {
+    document.head.insertAdjacentHTML(
+      'afterbegin',
+      '<xxx><link></xxx>'
+    )
+    style.mount({ id: 'gogogo with nested', head: true })
+    expect(document.head.firstElementChild?.firstElementChild?.getAttribute('cssr-id')).to.equal(
+      'gogogo with nested'
+    )
+  })
 })
 
 describe('force', () => {

--- a/packages/css-render/src/mount.ts
+++ b/packages/css-render/src/mount.ts
@@ -112,10 +112,13 @@ function mount (
   }
 
   if (head) {
-    document.head.insertBefore(
-      target,
-      document.head.querySelector('style, link')
-    )
+    const firstStyleOrLinkEl = document.head.querySelector('style, link')
+    // ensure Target and firstStyleOrLinkEl are under the same parent node
+    if (firstStyleOrLinkEl?.parentNode) {
+      firstStyleOrLinkEl.parentNode.insertBefore(target, firstStyleOrLinkEl)
+    } else {
+      document.head.appendChild(target)
+    }
   } else {
     document.head.appendChild(target)
   }


### PR DESCRIPTION
for fix:
Error: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node